### PR TITLE
Allow data driven commands during script run

### DIFF
--- a/panel/js/background/playback.js
+++ b/panel/js/background/playback.js
@@ -900,6 +900,9 @@ function doDomWait() {
 function doCommand() {
     let commands = getRecordsArray();
     let commandName = getCommandName(commands[currentPlayingCommandIndex]);
+	if(commandName.indexOf("${") !== -1){
+		commandName = convertVariableToString(commandName);
+	}
     var formalCommandName = formalCommands[commandName.trim().toLowerCase()];
     if (formalCommandName) {
         commandName = formalCommandName;


### PR DESCRIPTION
Hi, this allows the usage of variables as commands during script run.

store | type | cmd
store | id=someid | tgt
store | type this text | val
${cmd} | ${tgt} | ${val}

So you can set up a full page fill model in json, pass it to data driven, and iterate trough all of your page objects.
[objects.json.zip](https://github.com/katalon-studio/katalon-recorder/files/3610265/objects.json.zip)
