### PR TITLE
Add 'Close All Test Suites' Ability

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "description": "Selenium IDE alternative to record and export Selenium scripts. With reports & screenshots. Fast & open-source.",
     "manifest_version": 2,
     "name": "addon_name_placeholder",
-    "version": "3.9.0",
+    "version": "3.9.2",
     "homepage_url":"https://www.katalon.com/",
     "icons":
     {

--- a/panel/index.html
+++ b/panel/index.html
@@ -103,6 +103,7 @@
             <input id="load-testSuite-show" type="button" value="OpenSuite" style="display: none"></input>
             <button id="save-testSuite" style="display: none">SaveSuite</button>
             <button id="close-testSuite" style="display: none">CloseSuite</button>
+            <button id="close-all-testSuites" style="display: none">CloseAllSuites</button>
             <button id="add-testSuite" style="display: none">+Suite</button>
             <button id="add-testCase" style="display: none">+Case</button>
             <button id="delete-testCase" style="display: none">-Case</button>

--- a/panel/js/background/playback.js
+++ b/panel/js/background/playback.js
@@ -900,6 +900,9 @@ function doDomWait() {
 function doCommand() {
     let commands = getRecordsArray();
     let commandName = getCommandName(commands[currentPlayingCommandIndex]);
+	if(commandName.indexOf("${") !== -1){
+		commandName = convertVariableToString(commandName);
+	}
     var formalCommandName = formalCommands[commandName.trim().toLowerCase()];
     if (formalCommandName) {
         commandName = formalCommandName;

--- a/panel/js/katalon/selenium-ide/format/robot/robot.js
+++ b/panel/js/katalon/selenium-ide/format/robot/robot.js
@@ -64,9 +64,9 @@ function filterForRemoteControl(originalCommands) {
             c1 = c1.replace("//","xpath=//");
         }
 
-        if (c1.indexOf("/html") != -1)
+        if (c1.indexOf("/html") == 0)
         {
-            c1 = c1.replace("/html","xpath=/html");
+            c1 = "xpath=" + c1;
         }
         var key_str_start = c1.search(/\${KEY_.*}/)
         if (key_str_start != -1)


### PR DESCRIPTION
In this commit I added a new context menu option for test suites whereby you can choose to close all test suites at once.  This option still allows the user to save each test suite that has changes before it is closed.  I also added the name of the test suite in the save confirm pop-up.