### PR TITLE
fix: files are now saved with the .html extension

### DIFF
--- a/panel/js/IO/save_file.js
+++ b/panel/js/IO/save_file.js
@@ -81,7 +81,7 @@ function panelToFile(str) {
 var textFile = null,
     makeTextFile = function(text) {
         var data = new Blob([text], {
-            type: 'text/plain'
+            type: 'text/html'
         });
         // If we are replacing a previously generated file we need to
         // manually revoke the object URL to avoid memory leaks.


### PR DESCRIPTION
The test suites were saved as .txt while the test-suite open functionality expects a .html file. 
Therefore the saved(.txt) file could not be re-opened. 
This issue has been solved by setting the content type to text/html instead of text/plain.

This PR solves #44 
Original save windows: 
![image](https://user-images.githubusercontent.com/31991339/68752633-f139ff80-0603-11ea-9d8c-e31f1ea0111b.png)

New save window:

![image](https://user-images.githubusercontent.com/31991339/68752760-28101580-0604-11ea-9ffe-9eacea6a596a.png)

