### PR TITLE
Add relative=top and relative=up to selectFrame

### DIFF
--- a/panel/js/background/window-controller.js
+++ b/panel/js/background/window-controller.js
@@ -205,7 +205,7 @@ class ExtCommand {
         let result = frameLocation.match(/(index|relative) *= *([\d]+|parent|up|top)/i);
         if (result && result[2]) {
             let position = result[2];
-            if (position == "parent" | position == "up") {
+            if (position == "parent" || position == "up") {
                 this.currentPlayingFrameLocation = this.currentPlayingFrameLocation.slice(0, this.currentPlayingFrameLocation.lastIndexOf(':'));
             } else if(position == "top") {
                 this.currentPlayingFrameLocation = "root";

--- a/panel/js/background/window-controller.js
+++ b/panel/js/background/window-controller.js
@@ -202,12 +202,14 @@ class ExtCommand {
     }
 
     doSelectFrame(frameLocation) {
-        let result = frameLocation.match(/(index|relative) *= *([\d]+|parent)/i);
+        let result = frameLocation.match(/(index|relative) *= *([\d]+|parent|up|top)/i);
         if (result && result[2]) {
             let position = result[2];
-            if (position == "parent") {
+            if (position == "parent" | position == "up") {
                 this.currentPlayingFrameLocation = this.currentPlayingFrameLocation.slice(0, this.currentPlayingFrameLocation.lastIndexOf(':'));
-            } else {
+            } else if(position == "top") {
+                this.currentPlayingFrameLocation = "root";
+	    } else {
                 this.currentPlayingFrameLocation += ":" + position;
             }
             return this.wait("playingFrameLocations", this.currentPlayingTabId, this.currentPlayingFrameLocation);


### PR DESCRIPTION
The "selectFrame" command is missing the options to go back to the top/root frame and to use relative=up instead of relative=parent. I changed window-controller.js to add those.