### PR TITLE
Add some waitFor contextual menu actions, support more commands for protractor

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -214,6 +214,5 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 });
 
 browser.runtime.onConnect.addListener(function(m) {
-    console.log(m);
     port = m;
 });

--- a/background/background.js
+++ b/background/background.js
@@ -210,7 +210,6 @@ function createMenus() {
 
 var port;
 browser.contextMenus.onClicked.addListener(function(info, tab) {
-    console.log(info);
     port.postMessage({ cmd: info.menuItemId });
 });
 

--- a/background/background.js
+++ b/background/background.js
@@ -158,13 +158,63 @@ function createMenus() {
         documentUrlPatterns: ["<all_urls>"],
         contexts: ["all"]
     });
+    browser.contextMenus.create({
+        id: "waitForElementPresent",
+        title: "waitForElementPresent",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForElementNotPresent",
+        title: "waitForElementNotPresent",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForTextPresent",
+        title: "waitForTextPresent",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForTextNotPresent",
+        title: "waitForTextNotPresent",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForValue",
+        title: "waitForValue",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForNotValue",
+        title: "waitForNotValue",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForVisible",
+        title: "waitForVisible",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
+    browser.contextMenus.create({
+        id: "waitForNotVisible",
+        title: "waitForNotVisible",
+        documentUrlPatterns: ["<all_urls>"],
+        contexts: ["all"]
+    });
 }
 
 var port;
 browser.contextMenus.onClicked.addListener(function(info, tab) {
+    console.log(info);
     port.postMessage({ cmd: info.menuItemId });
 });
 
 browser.runtime.onConnect.addListener(function(m) {
+    console.log(m);
     port = m;
 });

--- a/content/recorder-handlers.js
+++ b/content/recorder-handlers.js
@@ -465,6 +465,8 @@ Recorder.addEventHandler('contextMenu', 'contextmenu', function(event) {
             self.record(m.cmd, [[tmpTitle]], '');
         } else if (m.cmd.includes("Value")) {
             self.record(m.cmd, tmpText, getInputValue(event.target));
+        } else if (m.cmd.includes('waitFor')) {
+            self.record(m.cmd, tmpText, '');
         }
         myPort.onMessage.removeListener(portListener);
     });

--- a/content/utils.js
+++ b/content/utils.js
@@ -183,6 +183,7 @@ function getText(element) {
     }
 
     text = normalizeNewlines(text);
+
     text = normalizeSpaces(text);
 
     return text.trim();
@@ -427,9 +428,9 @@ function isArray(x) {
 //browserbot
 function absolutify(url, baseUrl) {
     /** returns a relative url in its absolute form, given by baseUrl.
-     * 
+     *
      * This function is a little odd, because it can take baseUrls that
-     * aren't necessarily directories.  It uses the same rules as the HTML 
+     * aren't necessarily directories.  It uses the same rules as the HTML
      * &lt;base&gt; tag; if the baseUrl doesn't end with "/", we'll assume
      * that it points to a file, and strip the filename off to find its
      * base directory.
@@ -437,7 +438,7 @@ function absolutify(url, baseUrl) {
      * So absolutify("foo", "http://x/bar") will return "http://x/foo" (stripping off bar),
      * whereas absolutify("foo", "http://x/bar/") will return "http://x/bar/foo" (preserving bar).
      * Naturally absolutify("foo", "http://x") will return "http://x/foo", appropriately.
-     * 
+     *
      * @param url the url to make absolute; if this url is already absolute, we'll just return that, unchanged
      * @param baseUrl the baseUrl from which we'll absolutify, following the rules above.
      * @return 'url' if it was already absolute, or the absolutized version of url if it was not absolute.
@@ -1990,7 +1991,7 @@ function XPathEvaluator(newDefaultEngineName) {
         return xpath;
     }
 
-    /** 
+    /**
      * Returns the most sensible engine given the settings and the document
      * object.
      */
@@ -2122,7 +2123,7 @@ XPathEvaluator.prototype.init = function() {};
  *                    modify how the xpath is evaluated. Here's a listing of
  *                    the meaningful keys:
  *
- *                     contextNode: 
+ *                     contextNode:
  *                       the context node from which to evaluate the xpath. If
  *                       unspecified, the context will be the root document
  *                       element.
@@ -2203,14 +2204,14 @@ function eval_css(locator, inDocument) {
  * This function duplicates part of BrowserBot.findElement() to open up locator
  * evaluation on arbitrary documents. It returns a plain old array of located
  * elements found by using a Selenium locator.
- * 
+ *
  * Multiple results may be generated for xpath and CSS locators. Even though a
  * list could potentially be generated for other locator types, such as link,
  * we don't try for them, because they aren't very expressive location
  * strategies; if you want a list, use xpath or CSS. Furthermore, strategies
  * for these locators have been optimized to only return the first result. For
  * these types of locators, performance is more important than ideal behavior.
- * 
+ *
  * @param locator          a locator string
  * @param inDocument       the document in which to apply the locator
  * @param opt_contextNode  the context within which to evaluate the locator
@@ -2445,7 +2446,7 @@ function keys(object) {
  *               up from zero to the value of the start parameter. Note that
  *               the array returned will count up to but will not include this
  *               value.
- * @return       an array of consecutive integers. 
+ * @return       an array of consecutive integers.
  */
 function range(start, end) {
     if (arguments.length == 1) {
@@ -6178,7 +6179,7 @@ parseUri.options = {
 
         var isXML = function(elem) {
             // documentElement is verified for cases where it doesn't yet exist
-            // (such as loading iframes in IE - #4833) 
+            // (such as loading iframes in IE - #4833)
             var documentElement = (elem ? elem.ownerDocument || elem : 0).documentElement;
             return documentElement ? documentElement.nodeName !== "HTML" : false;
         };

--- a/panel/js/katalon/newformatters/protractorts.js
+++ b/panel/js/katalon/newformatters/protractorts.js
@@ -19,19 +19,19 @@ newFormatters.protractorts = function(name, commands) {
         css: (target) => {
             return `by.css("${target.replace(/\"/g, "\'")}")`
         },
-    
+
         id: (target) => {
             return `by.id("${target.replace(/\"/g, "\'")}")`
         },
-    
+
         link: (target) => {
             return `by.linkText("${target.replace(/\"/g, "\'")}")`
         },
-    
+
         name: (target) => {
             return `by.name("${target.replace(/\"/g, "\'")}")`
         },
-    
+
         tag_name: (target) => {
             return `by.tagName("${target.replace(/\"/g, "\'")}")`
         }
@@ -52,7 +52,7 @@ newFormatters.protractorts = function(name, commands) {
         '\${KEY_TAB}': 'Key.TAB',
         '\${KEY_HOME}': 'Key.HOME'
     }
-    
+
     // protracto api
     // https://www.protractortest.org/#/api
     // katalon
@@ -60,29 +60,76 @@ newFormatters.protractorts = function(name, commands) {
     const seleneseCommands = {
         "open": "await browser.get('_TARGET_');",
         "click": "await element(_BY_LOCATOR_).click();",
-        "clickAndWait": 
+        "clickAndWait":
             "const el__STEP_ = element(_BY_LOCATOR_);\n" +
-            "\t\tawait browser.wait(EC.elementToBeClickable(el__STEP_));\n" + 
+            "\t\tawait browser.wait(EC.elementToBeClickable(el__STEP_));\n" +
             "\t\tawait el__STEP_.click();",
         "doubleClick": "await browser.actions().doubleClick(element(_BY_LOCATOR_)).perform();",
+        "doubleClickAndWait":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.elementToBeClickable(el__STEP_));\n" +
+            "\t\tawait browser.actions().doubleClick(el__STEP_).perform();",
         "type": "await element(_BY_LOCATOR_).sendKeys('_VALUE_');",
+        "typeAndWait":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.elementToBeClickable(el__STEP_));\n" +
+            "\t\tawait element(_BY_LOCATOR_).sendKeys('_VALUE_');",
         "pause": "await browser.sleep(_VALUE_);",
         "refresh": "await browser.refresh();",
         "selectWindow":
             "const handles__STEP_ = await browser.getAllWindowHandles();\n" +
             "\t\tawait browser.switchTo().window(handles__STEP_[handles__STEP_.length - 1]);",
         "sendKeys": "await element(_BY_LOCATOR_).sendKeys(_SEND_KEY_);",
+        "sendKeysAndWait":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.presenceOf(el__STEP_));\n" +
+            "\t\tawait element(_BY_LOCATOR_).sendKeys(_SEND_KEY_);",
         "submit": "await element(_BY_LOCATOR_).submit();",
+        "submitAndWait":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.presenceOf(el__STEP_));\n" +
+            "\t\tawait element(_BY_LOCATOR_).submit();",
         "selectFrame":"await browser.switchTo().frame(element(_BY_LOCATOR_).getWebElement());",
         "select": "await element(_BY_LOCATOR_).element(by.cssContainingText('option', '_SELECT_OPTION_')).click();",
+        "selectAndWait":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.presenceOf(el__STEP_));\n" +
+            "\t\tawait browser.wait(EC.presenceOf(el__STEP_.element(by.cssContainingText('option', '_SELECT_OPTION_'))));\n" +
+            "await element(_BY_LOCATOR_).element(by.cssContainingText('option', '_SELECT_OPTION_')).click();",
         "goBack": "await browser.navigate().back();",
         "assertConfirmation": "await browser.switchTo().alert().accept();",
-        "verifyText": "expect(await element(_BY_LOCATOR_).getText()).toContain('_VALUE_STR_');",
-        "verifyTitle": "expect(await browser.getTitle()).toContain('_VALUE_STR_');",
-        "verifyValue": "expect(await element(_BY_LOCATOR_).getAttribute('value')).toContain('_VALUE_STR_')",
-        "assertText": "expect(await element(_BY_LOCATOR_).getText()).toContain('_VALUE_STR_');",
-        "assertTitle": "expect(await browser.getTitle()).toContain('_VALUE_STR_');",
-        "assertValue": "expect(await element(_BY_LOCATOR_).getAttribute('value')).toContain('_VALUE_STR_')"
+        "verifyText": "expect(await element(_BY_LOCATOR_).getText()).toContain(`_VALUE_STR_`);",
+        "verifyTitle": "expect(await browser.getTitle()).toContain(`_VALUE_STR_`);",
+        "verifyValue": "expect(await element(_BY_LOCATOR_).getAttribute('value')).toContain(`_VALUE_STR_`)",
+        "assertText": "expect(await element(_BY_LOCATOR_).getText()).toContain(`_VALUE_STR_`);",
+        "assertTitle": "expect(await browser.getTitle()).toContain(`_VALUE_STR_`);",
+        "assertValue": "expect(await element(_BY_LOCATOR_).getAttribute('value')).toContain(`_VALUE_STR_`)",
+        "waitForAlertNotPresent": "await browser.wait(EC.not(EC.alertIsPresent()))",
+        "waitForAlertPresent": "await browser.wait(EC.alertIsPresent())",
+        "waitForElementPresent":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.presenceOf(el__STEP_))",
+        "waitForElementNotPresent":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.stalenessOf(el__STEP_))",
+        "waitForTextPresent":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.textToBePresentInElement(el__STEP_, `_VALUE_STR_`))",
+        "waitForTextNotPresent":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.not(EC.textToBePresentInElement(el__STEP_, `_VALUE_STR_`)))",
+        "waitForValue":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.textToBePresentInValue(el__STEP_, `_VALUE_STR_`))",
+        "waitForNotValue":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.not(EC.textToBePresentInValue(el__STEP_, `_VALUE_STR_`)))",
+        "waitForVisible":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.visibilityOf(el__STEP_))",
+        "waitForNotVisible":
+            "const el__STEP_ = element(_BY_LOCATOR_);\n" +
+            "\t\tawait browser.wait(EC.invisibilityOf(el__STEP_))",
     }
 
     const header =
@@ -111,7 +158,7 @@ newFormatters.protractorts = function(name, commands) {
     }
 
     function commandExports(commands) {
-        
+
         let output = commands.reduce((accObj, commandObj) => {
             let {command, target, value} = commandObj
             let cmd = seleneseCommands[command]
@@ -174,4 +221,4 @@ newFormatters.protractorts = function(name, commands) {
         locator
     };
   }
-  
+


### PR DESCRIPTION
Add the following commands to the context menu :
- waitForElementPresent
- waitForElementNotPresent
- waitForTextPresent
- waitForTextNotPresent
- waitForValue
- waitForNotValue
- waitForVisible
- waitForNotVisible

Add support of the following command in protractor (TS) export :
- doubleClickAndWait
- typeAndWait
- sendKeysAndWait
- submitAndWait
- waitForAlertNotPresent
- waitForAlertPresent
- waitForElementPresent
- waitForElementNotPresent
- waitForTextPresent
- waitForTextNotPresent
- waitForValue
- waitForNotValue
- waitForVisible
- waitForNotVisible

Fix handling of quotes and double quotes in value in :
- verifyText
- verifyTitle
- verifyValue
- assertText
- assertTitle
- assertValue