### PR TITLE
fix Prototype-polluting function `utils`

### DIFF
--- a/content/utils.js
+++ b/content/utils.js
@@ -2923,6 +2923,11 @@ parseUri.options = {
             if ((options = arguments[i]) != null) {
                 // Extend the base object
                 for (name in options) {
+                    // Skip prototype-polluting properties
+                    if (name === "__proto__" || name === "constructor" || !Object.prototype.hasOwnProperty.call(options, name)) {
+                        continue;
+                    }
+
                     src = target[name];
                     copy = options[name];
 


### PR DESCRIPTION
https://github.com/katalon-studio/katalon-recorder/blob/2a0308eac1d5c0ebcd1b64aede619fa467a799f1/content/utils.js#L2943-L2943

fix the issue will add safeguards to the `jQuery.extend` function to prevent prototype pollution. Specifically:
1. Block the copying of dangerous property names like `__proto__` and `constructor`.
2. Ensure that only own properties of the source object (`options`) are copied to the target object.

This fix will involve modifying the loop on line 2925 to include checks for these conditions.

Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype`, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting. One way to cause prototype pollution is through use of an unsafe merge or extend function to recursively copy properties from one object to another, or through the use of a deep assignment function to assign to an unverified chain of property names. Such a function has the potential to modify any object reachable from the destination object, and the built-in `Object.prototype` is usually reachable through the special properties `__proto__` and `constructor.prototype`.


## POC
This function recursively copies properties from `src` to `dst`:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
However, if `src` is the object `{"__proto__": {"isAdmin": true}}`, it will inject the property `isAdmin: true` in `Object.prototype`.
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (dst.hasOwnProperty(key) && isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
Alternatively, block the `__proto__` and `constructor` properties:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (key === "__proto__" || key === "constructor") continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
## References
[lodash](https://hackerone.com/reports/380873), [jQuery](https://hackerone.com/reports/454365), [extend](https://hackerone.com/reports/381185), [just-extend](https://hackerone.com/reports/430291), [merge.recursive](https://hackerone.com/reports/381194)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)
